### PR TITLE
Added security to Keycloak authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,29 @@
 
 > Compatibility is based on where I have tested the plugin and if it worked without issue.  
 
+- Java 11+ (This plugin does not support Java 1.8)
 - PaperMC 1.16+
 - Bukkit 1.16+
 
 This plugin uses bstats for metrics, check out the bstats page at `https://bstats.org/plugin/bukkit/Doubletap/9717`
+## Setup
+
+### Server Owners
+
+- Download or compile a jar and place it into your `plugins` folder.
+- Start or Restart the server. 
+- Edit the file located at: `./plugins/Doubletap/config.json`
+
+> Currently, the config.json starts with a base authorizer as default. I suggest you change this to your liking. 
+> What I have done is use Keycloak for my role authorizer. 
+> What you could do is put the graphql interface behind http basic auth and make admin the base. 
+> Or perhaps, use netlify or keycloak. 
 
 ## Query Examples
 
 ### Whitelist
 
 ![](./docs/assets/query-example-01.png)
-
-## Setup
-
-### Server Owners
-
-- Download or compile a jar and place it into your `plugins` folder.
 
 ### Developers
 
@@ -55,7 +62,7 @@ I was inspired by the following plugins:
 
 ### Plans for the future
 
-- Currently, I will enable harmless endpoints for information and limit what is publicly available. 
-- I intend to implement policy based authorization, which in turn will allow operators to design auth schemas for people who are signed in. 
-- Authentication will be enforced via JWT or similar authorization structure. With the end goal of making authorization simple to implement on a frontend or server to server application. 
+- Completed: Currently, I will enable harmless endpoints for information and limit what is publicly available. 
+- Completed: I intend to implement policy based authorization, which in turn will allow operators to design auth schemas for people who are signed in. 
+- Completed: Authentication will be enforced via JWT or similar authorization structure. With the end goal of making authorization simple to implement on a frontend or server to server application. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 group = 'doubletap.boop.ninja'
-version = '1.0-UNTESTED-SNAPSHOT'
+version = '1.0-SNAPSHOT'
 
 
 compileJava   {

--- a/src/main/java/doubletap/boop/ninja/doubletap/Authorizors/Keycloak/KeycloakJWT.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Authorizors/Keycloak/KeycloakJWT.java
@@ -14,10 +14,16 @@ public class KeycloakJWT {
     public String azp;
     public HashMap<String, HashMap<String, String[]>> resource_access;
 
+    private URI keycloakHost() {
+        String hostname = Doubletap.config.authorizerOptions.get("host");
+        String realm = Doubletap.config.authorizerOptions.get("realm");
+        return URI.create(String.format("%s/auth/realms/%s/protocol/openid-connect/userinfo", hostname, realm));
+    }
+
     public boolean isValid(String fullJWT)  {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(this.iss + "/protocol/openid-connect/userinfo"))
+                .uri(keycloakHost())
                 .header("Authorization", fullJWT)
                 .build();
         try {

--- a/src/main/java/doubletap/boop/ninja/doubletap/Entities/Config.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Entities/Config.java
@@ -1,8 +1,12 @@
 package doubletap.boop.ninja.doubletap.Entities;
 
+import java.util.HashMap;
+
 public class Config {
     public int port;
-    public String authorizer = "base";
     public boolean debug = false;
+
+    public String authorizer = "base";
+    public HashMap<String, String> authorizerOptions;
 
 }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,5 +1,9 @@
 {
   "port": 8101,
   "debug": false,
-  "authorizer": "base"
+  "authorizer": "base",
+  "authorizerOptions": {
+    "host": "SEE README",
+    "realm": "SEE README"
+  }
 }


### PR DESCRIPTION
Previously, we were looking at the jwt to pull information. That was temporary as we should be focusing on supplied data when running. That way it is no longer a security risk. 