### PR TITLE
Fixed add/remove whitelist 

### DIFF
--- a/src/main/java/doubletap/boop/ninja/doubletap/Controllers/Graphql/LocalRuntimeWiring.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Controllers/Graphql/LocalRuntimeWiring.java
@@ -3,14 +3,13 @@ package doubletap.boop.ninja.doubletap.Controllers.Graphql;
 import doubletap.boop.ninja.doubletap.Authorizors.Base.Policy;
 import doubletap.boop.ninja.doubletap.Authorizors.Base.Role;
 import doubletap.boop.ninja.doubletap.Mutations.WhitelistMutations;
+import doubletap.boop.ninja.doubletap.Queries.OfflinePlayerFetcher;
 import doubletap.boop.ninja.doubletap.Queries.ServerFetcher;
 import doubletap.boop.ninja.doubletap.Queries.WorldFetcher;
 import graphql.schema.PropertyDataFetcher;
 import graphql.schema.idl.TypeRuntimeWiring;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 import static org.bukkit.Bukkit.getPlayer;
 import static org.bukkit.Bukkit.getServer;
@@ -78,7 +77,8 @@ public class LocalRuntimeWiring {
     }
 
     private TypeRuntimeWiring.Builder offlinePlayer(TypeRuntimeWiring.Builder builder) {
-        return playerBaseType(builder);
+        return playerBaseType(builder)
+                .dataFetcher("name", OfflinePlayerFetcher::playerName);
     }
 
     private TypeRuntimeWiring.Builder whitelistQuery(TypeRuntimeWiring.Builder builder) {

--- a/src/main/java/doubletap/boop/ninja/doubletap/External/Mojang/PlayerInfo.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/External/Mojang/PlayerInfo.java
@@ -1,0 +1,17 @@
+package doubletap.boop.ninja.doubletap.External.Mojang;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+public class PlayerInfo {
+    public String id;
+    public String name;
+    public Long changedToAt = 0L;
+
+    public UUID idToUUID() {
+        return new UUID(
+                new BigInteger(this.id.substring(0, 16), 16).longValue(),
+                new BigInteger(this.id.substring(16), 16).longValue()
+        );
+    }
+}

--- a/src/main/java/doubletap/boop/ninja/doubletap/External/MojangAPI.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/External/MojangAPI.java
@@ -1,0 +1,28 @@
+package doubletap.boop.ninja.doubletap.External;
+
+import com.google.gson.Gson;
+import doubletap.boop.ninja.doubletap.External.Mojang.PlayerInfo;
+import doubletap.boop.ninja.doubletap.Utils.HttpHelper;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.UUID;
+
+import static java.lang.String.format;
+
+public class MojangAPI {
+
+    public static PlayerInfo fetchPlayerById(UUID id) {
+        String url = format("https://api.mojang.com/user/profiles/%s/names", id.toString());
+        String response = HttpHelper.get(url, format("Player %s not found!", id));
+        PlayerInfo[] playerInfos = new Gson().fromJson(response, PlayerInfo[].class);
+        Arrays.sort(playerInfos, Comparator.comparingLong(p -> p.changedToAt));
+        return playerInfos[playerInfos.length - 1];
+    }
+
+    public static PlayerInfo fetchPlayerByName(String name) {
+        String url = format("https://api.mojang.com/users/profiles/minecraft/%s", name);
+        String response = HttpHelper.get(url, format("Player %s not found!", name));
+        return new Gson().fromJson(response, PlayerInfo.class);
+    }
+}

--- a/src/main/java/doubletap/boop/ninja/doubletap/Queries/OfflinePlayerFetcher.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Queries/OfflinePlayerFetcher.java
@@ -1,0 +1,20 @@
+package doubletap.boop.ninja.doubletap.Queries;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.PropertyDataFetcher;
+import org.bukkit.OfflinePlayer;
+
+import java.util.UUID;
+
+import static doubletap.boop.ninja.doubletap.External.MojangAPI.fetchPlayerById;
+
+public class OfflinePlayerFetcher {
+    public static String playerName(DataFetchingEnvironment environment) {
+        UUID id = PropertyDataFetcher.fetching(OfflinePlayer::getUniqueId).get(environment);
+        String name = PropertyDataFetcher.fetching(OfflinePlayer::getName).get(environment);
+        if (name == null) {
+            return fetchPlayerById(id).name;
+        }
+        return PropertyDataFetcher.fetching(OfflinePlayer::getName).get(environment);
+    }
+}

--- a/src/main/java/doubletap/boop/ninja/doubletap/Queries/ServerFetcher.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Queries/ServerFetcher.java
@@ -1,13 +1,20 @@
 package doubletap.boop.ninja.doubletap.Queries;
 
 import graphql.schema.DataFetchingEnvironment;
+import org.bukkit.OfflinePlayer;
 
+import static doubletap.boop.ninja.doubletap.Doubletap.logger;
 import static org.bukkit.Bukkit.getServer;
 
 public class ServerFetcher {
 
-    public static Object[] whiteListedPlayers(DataFetchingEnvironment environment) {
-        return getServer().getWhitelistedPlayers().toArray();
+    public static OfflinePlayer[] whiteListedPlayers(DataFetchingEnvironment environment) {
+        OfflinePlayer[] players = getServer().getWhitelistedPlayers().toArray(OfflinePlayer[]::new);
+        for (OfflinePlayer player : players) {
+            logger.info(player.getUniqueId().toString());
+            logger.info(player.getName());
+        }
+        return players;
     }
 
 

--- a/src/main/java/doubletap/boop/ninja/doubletap/Utils/HttpHelper.java
+++ b/src/main/java/doubletap/boop/ninja/doubletap/Utils/HttpHelper.java
@@ -1,0 +1,42 @@
+package doubletap.boop.ninja.doubletap.Utils;
+
+import graphql.GraphQLException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static java.lang.String.format;
+
+public class HttpHelper {
+    public static HttpClient client() {
+        return HttpClient.newHttpClient();
+    }
+    public static HttpRequest request(String url) {
+        return HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .build();
+    }
+
+    public static String get(String url) {
+        try {
+            HttpResponse<String> response =
+                    client().send(request(url), HttpResponse.BodyHandlers.ofString());
+            return response.body();
+        } catch (IOException | InterruptedException error) {
+            throw new GraphQLException(format("HTTP error for %s", url));
+        }
+    }
+
+    public static String get(String url, String errorMessage) {
+        try {
+            HttpResponse<String> response =
+                    client().send(request(url), HttpResponse.BodyHandlers.ofString());
+            return response.body();
+        } catch (IOException | InterruptedException error) {
+            throw new GraphQLException(errorMessage);
+        }
+    }
+}

--- a/src/main/resources/schema.gql
+++ b/src/main/resources/schema.gql
@@ -17,16 +17,13 @@ type MutationType {
 
 type OfflinePlayer {
     bedSpawnLocation: Location
-    " Uses Custom Fetcher"
-    isBanned: Boolean!
-    " Uses Custom Fetcher"
-    isOnline: Boolean!
-    " Uses Custom Fetcher"
-    isWhitelisted: Boolean!
-    lastPlayed: Float!
-    lastSeen: Float!
+    isBanned: Boolean
+    isOnline: Boolean
+    isWhitelisted: Boolean
+    lastPlayed: Float
+    lastSeen: Float
     name: String!
-    player: Player!
+    player: Player
     uniqueId: ID!
 }
 


### PR DESCRIPTION
## Previously
Whitelist users was looking at cached offline users which only works if they have already joined the server. 

## Current
Whitelisted users when being added or removed now make a web call to Mojang for their user ID or current username. Then it runs the remove section. This also changes the schema as an OfflinePlayer could have a lot of 